### PR TITLE
Update music_assistant_blueprint.yaml with triggers that support area

### DIFF
--- a/music_assistant_blueprint.yaml
+++ b/music_assistant_blueprint.yaml
@@ -82,7 +82,7 @@ triggers:
     command:
       - "(play|listen to) [the ]playlist {media_name} (in|on|using) [the ]{area_or_player_name}[ (with|using) {radio_mode}]"
     id: playlist
-    - trigger: conversation
+  - trigger: conversation
     command:
       - "(play|listen to) [the ](album|ep|record|compilation|single) {media_name} [by [the ](artist|band|group) {artist}] (in|on|using) [the ]{area_or_player_name}[ (with|using) {radio_mode}]"
     id: album

--- a/music_assistant_blueprint.yaml
+++ b/music_assistant_blueprint.yaml
@@ -84,7 +84,7 @@ triggers:
     id: playlist
   - trigger: conversation
     command:
-      - "(play|listen to) [the ](album|ep|record|compilation|single) {media_name} [by [the ](artist|band|group) {artist}] (in|on|using) [the ]{area_or_player_name}[ (with|using) {radio_mode}]"
+      - "(play|listen to) [the ](album|ep|record|compilation|single) {media_name} [by [the ](artist|band|group) {artist}] [(with|using) {radio_mode}]"
     id: album
   - trigger: conversation
     command:

--- a/music_assistant_blueprint.yaml
+++ b/music_assistant_blueprint.yaml
@@ -82,6 +82,26 @@ triggers:
     command:
       - "(play|listen to) [the ]playlist {media_name} (in|on|using) [the ]{area_or_player_name}[ (with|using) {radio_mode}]"
     id: playlist
+    - trigger: conversation
+    command:
+      - "(play|listen to) [the ](album|ep|record|compilation|single) {media_name} [by [the ](artist|band|group) {artist}] (in|on|using) [the ]{area_or_player_name}[ (with|using) {radio_mode}]"
+    id: album
+  - trigger: conversation
+    command:
+      - "(play|listen to) [the ](track|song) {media_name} [by [the ](artist|band|group) {artist}] [(with|using) {radio_mode}]"
+    id: track
+  - trigger: conversation
+    command:
+      - "(play|listen to) [the ](artist|band|group) {media_name} [(with|using) {radio_mode}]"
+    id: artist
+  - trigger: conversation
+    command:
+      - "(play|listen to) [the ]((radio station)|(radio)|(station)) {media_name}"
+    id: radio
+  - trigger: conversation
+    command:
+      - "(play|listen to) [the ]playlist {media_name} [(with|using) {radio_mode}]"
+    id: playlist
 conditions: []
 actions:
   - variables:

--- a/music_assistant_blueprint.yaml
+++ b/music_assistant_blueprint.yaml
@@ -64,43 +64,23 @@ blueprint:
 triggers:
   - trigger: conversation
     command:
-      - "(play|listen to) [the ](album|ep|record|compilation|single) {media_name} [by [the ](artist|band|group) {artist}] (in|on|using) [the ]{area_or_player_name}[ (with|using) {radio_mode}]"
+      - "(play|listen to) [the ](album|ep|record|compilation|single) {media_name} [by [the ](artist|band|group) {artist}] [(in|on|using) [the ]{area_or_player_name}][ (with|using) {radio_mode}]"
     id: album
   - trigger: conversation
     command:
-      - "(play|listen to) [the ](track|song) {media_name} [by [the ](artist|band|group) {artist}] (in|on|using) [the ]{area_or_player_name}[ (with|using) {radio_mode}]"
+      - "(play|listen to) [the ](track|song) {media_name} [by [the ](artist|band|group) {artist}] [(in|on|using) [the ]{area_or_player_name}][ (with|using) {radio_mode}]"
     id: track
   - trigger: conversation
     command:
-      - "(play|listen to) [the ](artist|band|group) {media_name} (in|on|using) [the ]{area_or_player_name}[ (with|using) {radio_mode}]"
+      - "(play|listen to) [the ](artist|band|group) {media_name} [(in|on|using) [the ]{area_or_player_name}][ (with|using) {radio_mode}]"
     id: artist
   - trigger: conversation
     command:
-      - "(play|listen to) [the ]((radio station)|(radio)|(station)) {media_name} (in|on|using) [the ]{area_or_player_name}"
+      - "(play|listen to) [the ]((radio station)|(radio)|(station)) {media_name} [(in|on|using) [the ]{area_or_player_name}]"
     id: radio
   - trigger: conversation
     command:
-      - "(play|listen to) [the ]playlist {media_name} (in|on|using) [the ]{area_or_player_name}[ (with|using) {radio_mode}]"
-    id: playlist
-  - trigger: conversation
-    command:
-      - "(play|listen to) [the ](album|ep|record|compilation|single) {media_name} [by [the ](artist|band|group) {artist}] [(with|using) {radio_mode}]"
-    id: album
-  - trigger: conversation
-    command:
-      - "(play|listen to) [the ](track|song) {media_name} [by [the ](artist|band|group) {artist}] [(with|using) {radio_mode}]"
-    id: track
-  - trigger: conversation
-    command:
-      - "(play|listen to) [the ](artist|band|group) {media_name} [(with|using) {radio_mode}]"
-    id: artist
-  - trigger: conversation
-    command:
-      - "(play|listen to) [the ]((radio station)|(radio)|(station)) {media_name}"
-    id: radio
-  - trigger: conversation
-    command:
-      - "(play|listen to) [the ]playlist {media_name} [(with|using) {radio_mode}]"
+      - "(play|listen to) [the ]playlist {media_name} [(in|on|using) [the ]{area_or_player_name}][ (with|using) {radio_mode}]"
     id: playlist
 conditions: []
 actions:


### PR DESCRIPTION
Adding in trigger sentences that do not require area or device to be explicitly stated, to support area context awareness.
Fixes #6 